### PR TITLE
feat(docker): substitute SINGLETON_* at container start instead of build-at-boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,18 @@ EXPOSE 24900
 
 ENV NODE_ENV=prod
 
+# Bake the bundle ONCE at image build time using sentinel placeholders.
+# The runtime entrypoint (`scripts/cmd.sh`) replaces these with the
+# actual SINGLETON_* env values via `sed` on the prebuilt `dist/`.
+# Boot time drops from 2-5 min (build at start) to seconds. Pod restarts
+# on secret rotation become viable in production clusters.
+#
+# Non-Docker deployments (e.g. Vercel) still build at deploy time with
+# concrete env values; this RUN only affects this image's `dist/`.
+ENV VITE_SINGLETON_MODE=__MEILI_UI_REPLACE_SINGLETON_MODE__ \
+    VITE_SINGLETON_HOST=__MEILI_UI_REPLACE_SINGLETON_HOST__ \
+    VITE_SINGLETON_API_KEY=__MEILI_UI_REPLACE_SINGLETON_API_KEY__
+RUN pnpm run build:docker
+
 RUN ["chmod", "+x", "./scripts/cmd.sh"]
 ENTRYPOINT ["./scripts/cmd.sh"]
-

--- a/scripts/cmd.sh
+++ b/scripts/cmd.sh
@@ -1,26 +1,78 @@
 #!/bin/bash
+set -e
 
-# transform singleton mode environment variables
-if [ ! -z "$SINGLETON_HOST" ]; then
-  export VITE_SINGLETON_HOST="$SINGLETON_HOST"
-fi
+# The Docker image is built once with placeholder values for the
+# SINGLETON_* env vars (see Dockerfile). At container start we substitute
+# the real values from the runtime environment into the prebuilt `dist/`
+# bundle, then serve. This keeps container boot O(seconds) instead of
+# the 2-5 min a fresh `vite build` takes on a constrained pod, and
+# makes secret rotation / rolling updates viable in clusters.
+#
+# Backwards compatibility: if `dist/` does not exist yet (e.g. someone
+# runs `cmd.sh` outside a built image, or against a base image without
+# the pre-build step), we fall back to the old behavior — build at
+# start with the runtime env vars baked in.
 
-if [ ! -z "$SINGLETON_API_KEY" ]; then
-  export VITE_SINGLETON_API_KEY="$SINGLETON_API_KEY"
-fi
+DIST_DIR="${DIST_DIR:-/opt/meilisearch-ui/dist}"
 
-if [ ! -z "$SINGLETON_MODE" ]; then
-  export VITE_SINGLETON_MODE="$SINGLETON_MODE"
-  if [ "$SINGLETON_MODE" = "true" ]; then
-    echo "Singleton mode enabled"
+if [ -d "$DIST_DIR" ] && [ -n "$(ls -A "$DIST_DIR" 2>/dev/null)" ]; then
+  echo "Prebuilt dist/ detected — substituting runtime singleton config."
+
+  # Default unset placeholders to empty so the bundle resolves to
+  # multi-instance mode rather than crashing on a literal placeholder
+  # string in the browser.
+  : "${SINGLETON_MODE:=}"
+  : "${SINGLETON_HOST:=}"
+  : "${SINGLETON_API_KEY:=}"
+
+  # The placeholders are sentinel strings unique to this entrypoint;
+  # they appear in the bundle exactly where the build resolved
+  # `import.meta.env.VITE_SINGLETON_*`. Scope the sed pass to the JS,
+  # CSS, and HTML emitted by Vite to avoid touching node_modules.
+  find "$DIST_DIR" -type f \( -name '*.js' -o -name '*.css' -o -name '*.html' \) \
+    -exec sed -i \
+      -e "s|__MEILI_UI_REPLACE_SINGLETON_MODE__|${SINGLETON_MODE}|g" \
+      -e "s|__MEILI_UI_REPLACE_SINGLETON_HOST__|${SINGLETON_HOST}|g" \
+      -e "s|__MEILI_UI_REPLACE_SINGLETON_API_KEY__|${SINGLETON_API_KEY}|g" \
+      {} +
+
+  # Safety net: refuse to start if any placeholder slipped through
+  # (e.g. the bundler emitted an escaped form sed missed). Better a
+  # crash-loop than serving sentinel strings to the browser.
+  if grep -rqE '__MEILI_UI_REPLACE_SINGLETON_(MODE|HOST|API_KEY)__' "$DIST_DIR"; then
+    echo "ERROR: singleton placeholder still present in $DIST_DIR after substitution." >&2
+    grep -rlE '__MEILI_UI_REPLACE_SINGLETON_(MODE|HOST|API_KEY)__' "$DIST_DIR" >&2 || true
+    exit 1
   fi
+
+  if [ "$SINGLETON_MODE" = "true" ]; then
+    echo "Singleton mode enabled (host: ${SINGLETON_HOST:-<unset>})"
+  fi
+else
+  echo "No prebuilt dist/ found — building at start with current env."
+
+  # Legacy build-at-start path. Mirrors the previous behavior of this
+  # script: copy SINGLETON_* into the VITE_-namespaced env vars Vite
+  # expects, then build + preview.
+  if [ -n "${SINGLETON_HOST:-}" ]; then
+    export VITE_SINGLETON_HOST="$SINGLETON_HOST"
+  fi
+  if [ -n "${SINGLETON_API_KEY:-}" ]; then
+    export VITE_SINGLETON_API_KEY="$SINGLETON_API_KEY"
+  fi
+  if [ -n "${SINGLETON_MODE:-}" ]; then
+    export VITE_SINGLETON_MODE="$SINGLETON_MODE"
+    if [ "$SINGLETON_MODE" = "true" ]; then
+      echo "Singleton mode enabled"
+    fi
+  fi
+
+  pnpm run build
 fi
 
 export BASE_PATH="${BASE_PATH:-/}"
-
 if [ "$BASE_PATH" != "/" ]; then
   echo "Custom base path: $BASE_PATH"
 fi
 
-pnpm run build
 pnpm run preview


### PR DESCRIPTION
Fixes #269.

## Summary

- Bake the Vite bundle **once** at image build time using sentinel placeholders (`__MEILI_UI_REPLACE_SINGLETON_{MODE,HOST,API_KEY}__`).
- At container start, `scripts/cmd.sh` `sed`-substitutes the real `SINGLETON_*` env values into the prebuilt `dist/` and runs `pnpm run preview`.
- Boot time drops from 2–5 min (full `vite build` on every container start) to seconds.

This makes secret rotation and rolling updates viable in production clusters: today, every `kubectl rollout restart` (or anything that triggers a pod restart, like Stakater Reloader on a secret change) blocks readiness for the full build duration.

## Backwards compatibility

`scripts/cmd.sh` falls back to the previous build-at-start behavior when `dist/` is empty, so:

- Non-Docker deployments (e.g. Vercel) — unaffected, they build at deploy time with concrete env values via `scripts/post-build.js`.
- Anyone running `scripts/cmd.sh` directly against a tree without a prebuilt `dist/` — unaffected.
- Existing Docker callers — same env-var contract (`SINGLETON_MODE`, `SINGLETON_HOST`, `SINGLETON_API_KEY`, `BASE_PATH`).

The placeholder strings are unique sentinels (`__MEILI_UI_REPLACE_SINGLETON_*__`) and follow the same pattern this repo already uses for `MEILI_UI_REPLACE_BASE_PATH` (see `scripts/post-build.js`).

## Safety net

If a placeholder slips through the `sed` pass (e.g. the bundler emits an escaped form), the entrypoint exits non-zero rather than serve sentinel strings to the browser.

## Test plan

- [x] `docker build` produces a `dist/` with placeholders.
- [x] `docker run` with `SINGLETON_MODE=true` substitutes correctly; the bundle no longer contains placeholder strings.
- [x] `docker run` with no `SINGLETON_*` set substitutes placeholders to empty (multi-instance mode).
- [x] Backwards-compat: removing `dist/` from the image falls back to build-at-start path.

Happy to iterate if a different approach (e.g. a `dist/config.js` runtime endpoint) is preferred — see linked issue for the alternative discussed.